### PR TITLE
Expose query timing details in JDBC client

### DIFF
--- a/QueryEngine/Execute.cpp
+++ b/QueryEngine/Execute.cpp
@@ -1752,7 +1752,7 @@ Executor::getUniqueThreadSharedResultSets(
 namespace {
 
 ReductionCode get_reduction_code(
-    const size_t executor_id,
+    Executor* executor,
     std::vector<std::pair<ResultSetPtr, std::vector<size_t>>>& results_per_device,
     int64_t* compilation_queue_time) {
   auto clock_begin = timer_start();
@@ -1761,9 +1761,11 @@ ReductionCode get_reduction_code(
   ResultSetReductionJIT reduction_jit(this_result_set->getQueryMemDesc(),
                                       this_result_set->getTargetInfos(),
                                       this_result_set->getTargetInitVals(),
-                                      executor_id);
+                                      executor->getExecutorId());
   ReductionCode result = reduction_jit.codegen();
-  *compilation_queue_time = timer_stop(clock_begin);
+  auto elapsed = timer_stop(clock_begin);
+  *compilation_queue_time = elapsed;
+  executor->addCompilationTime(elapsed);
   return result;
 };
 
@@ -1779,7 +1781,7 @@ ResultSetPtr Executor::reduceMultiDeviceResultSets(
   int64_t compilation_queue_time = 0;
   if (results_per_device.size() > size_t(1)) {
     const auto reduction_code =
-        get_reduction_code(executor_id_, results_per_device, &compilation_queue_time);
+        get_reduction_code(const_cast<Executor*>(this), results_per_device, &compilation_queue_time);
 
     for (size_t i = 1; i < results_per_device.size(); ++i) {
       reduced_results->getStorage()->reduce(
@@ -2181,6 +2183,8 @@ ResultSetPtr Executor::executeWorkUnit(size_t& max_groups_buffer_entry_guess,
     if (result) {
       result->setKernelQueueTime(kernel_queue_time_ms_);
       result->addCompilationQueueTime(compilation_queue_time_ms_);
+      result->setKernelExecutionTime(kernel_execution_time_ms_);
+      result->addCompilationTime(compilation_time_ms_);
       if (eo.just_validate) {
         result->setValidationOnlyRes();
       }
@@ -2202,6 +2206,8 @@ ResultSetPtr Executor::executeWorkUnit(size_t& max_groups_buffer_entry_guess,
     if (result) {
       result->setKernelQueueTime(kernel_queue_time_ms_);
       result->addCompilationQueueTime(compilation_queue_time_ms_);
+      result->setKernelExecutionTime(kernel_execution_time_ms_);
+      result->addCompilationTime(compilation_time_ms_);
       if (eo.just_validate) {
         result->setValidationOnlyRes();
       }
@@ -3159,6 +3165,7 @@ void Executor::launchKernelsImpl(SharedKernelContext& shared_context,
                                  std::vector<std::unique_ptr<ExecutionKernel>>&& kernels,
                                  const ExecutorDeviceType device_type,
                                  const size_t requested_num_threads) {
+  auto exec_begin = timer_start();
 #ifdef HAVE_TBB
   const size_t num_threads =
       requested_num_threads == Executor::auto_num_threads
@@ -3236,6 +3243,7 @@ void Executor::launchKernelsImpl(SharedKernelContext& shared_context,
       shared_context.addDeviceResults(std::move(results), {});
     }
   }
+  kernel_execution_time_ms_ += timer_stop(exec_begin);
 }
 
 void Executor::launchKernelsLocked(
@@ -4385,6 +4393,8 @@ void Executor::nukeOldState(const bool allow_lazy_fetch,
                             const RelAlgExecutionUnit* ra_exe_unit) {
   kernel_queue_time_ms_ = 0;
   compilation_queue_time_ms_ = 0;
+  kernel_execution_time_ms_ = 0;
+  compilation_time_ms_ = 0;
   const bool contains_left_deep_outer_join =
       ra_exe_unit && std::find_if(ra_exe_unit->join_quals.begin(),
                                   ra_exe_unit->join_quals.end(),

--- a/QueryEngine/Execute.h
+++ b/QueryEngine/Execute.h
@@ -1271,6 +1271,7 @@ class Executor {
                     const PlanState::DeletedColumnsMap& deleted_cols_map,
                     const RelAlgExecutionUnit* ra_exe_unit);
 
+
   std::shared_ptr<CompilationContext> optimizeAndCodegenCPU(
       llvm::Function*,
       llvm::Function*,
@@ -1351,6 +1352,7 @@ class Executor {
   ExecutorId getExecutorId() const {
     return executor_id_;
   };
+  void addCompilationTime(int64_t t) { compilation_time_ms_ += t; }
   QuerySessionId& getCurrentQuerySession(
       heavyai::shared_lock<heavyai::shared_mutex>& read_lock);
   QuerySessionStatus::QueryStatus getQuerySessionStatus(
@@ -1594,6 +1596,8 @@ class Executor {
 
   int64_t kernel_queue_time_ms_ = 0;
   int64_t compilation_queue_time_ms_ = 0;
+  int64_t kernel_execution_time_ms_ = 0;
+  int64_t compilation_time_ms_ = 0;
 
   // Singleton instance used for an execution unit which is a project with window
   // functions.

--- a/QueryEngine/NativeCodegen.cpp
+++ b/QueryEngine/NativeCodegen.cpp
@@ -2931,6 +2931,7 @@ Executor::compileWorkUnit(const std::vector<InputTableInfo>& query_infos,
                           RenderInfo* render_info) {
   auto timer = DEBUG_TIMER(__func__);
 
+  auto compile_begin = timer_start();
   if (co.device_type == ExecutorDeviceType::GPU) {
     if (!cuda_mgr) {
       throw QueryMustRunOnCpu();
@@ -3329,7 +3330,7 @@ Executor::compileWorkUnit(const std::vector<InputTableInfo>& query_infos,
   }
 
   // Generate final native code from the LLVM IR.
-  return std::make_tuple(
+  auto result = std::make_tuple(
       CompilationResult{
           co.device_type == ExecutorDeviceType::CPU
               ? optimizeAndCodegenCPU(query_func, multifrag_query_func, live_funcs, co)
@@ -3345,6 +3346,8 @@ Executor::compileWorkUnit(const std::vector<InputTableInfo>& query_infos,
           llvm_ir,
           std::move(gpu_smem_context)},
       std::move(query_mem_desc));
+  compilation_time_ms_ += timer_stop(compile_begin);
+  return result;
 }
 
 void Executor::insertErrorCodeChecker(llvm::Function* query_func,

--- a/QueryEngine/ResultSet.cpp
+++ b/QueryEngine/ResultSet.cpp
@@ -190,7 +190,7 @@ ResultSet::ResultSet(int64_t queue_time_ms,
     , thread_idx_(-1)
     , fetched_so_far_(0)
     , row_set_mem_owner_(row_set_mem_owner)
-    , timings_(QueryExecutionTimings{queue_time_ms, render_time_ms, 0, 0})
+    , timings_(QueryExecutionTimings{queue_time_ms, render_time_ms, 0, 0, 0, 0})
     , separate_varlen_storage_valid_(false)
     , just_explain_(true)
     , for_validation_only_(false)
@@ -726,6 +726,14 @@ void ResultSet::setKernelQueueTime(const int64_t kernel_queue_time) {
 
 void ResultSet::addCompilationQueueTime(const int64_t compilation_queue_time) {
   timings_.compilation_queue_time += compilation_queue_time;
+}
+
+void ResultSet::setKernelExecutionTime(const int64_t kernel_execution_time) {
+  timings_.kernel_execution_time = kernel_execution_time;
+}
+
+void ResultSet::addCompilationTime(const int64_t compilation_time) {
+  timings_.compilation_time += compilation_time;
 }
 
 int64_t ResultSet::getQueueTime() const {

--- a/QueryEngine/ResultSet.h
+++ b/QueryEngine/ResultSet.h
@@ -386,13 +386,22 @@ class ResultSet {
     int64_t render_time{0};
     int64_t compilation_queue_time{0};
     int64_t kernel_queue_time{0};
+    int64_t kernel_execution_time{0};
+    int64_t compilation_time{0};
   };
 
   void setQueueTime(const int64_t queue_time);
   void setKernelQueueTime(const int64_t kernel_queue_time);
   void addCompilationQueueTime(const int64_t compilation_queue_time);
+  void setKernelExecutionTime(const int64_t kernel_execution_time);
+  void addCompilationTime(const int64_t compilation_time);
 
   int64_t getQueueTime() const;
+  int64_t getExecutorQueueTime() const { return timings_.executor_queue_time; }
+  int64_t getKernelQueueTime() const { return timings_.kernel_queue_time; }
+  int64_t getCompilationQueueTime() const { return timings_.compilation_queue_time; }
+  int64_t getKernelExecutionTime() const { return timings_.kernel_execution_time; }
+  int64_t getCompilationTime() const { return timings_.compilation_time; }
   int64_t getRenderTime() const;
 
   void moveToBegin() const;

--- a/SQLFrontend/heavysql.cpp
+++ b/SQLFrontend/heavysql.cpp
@@ -1382,9 +1382,17 @@ int main(int argc, char** argv) {
             }
             if (print_timing) {
               std::cout << "Execution time: " << context.query_return.execution_time_ms
-                        << " ms,"
-                        << " Total time: " << context.query_return.total_time_ms << " ms"
+                        << " ms, Total time: " << context.query_return.total_time_ms << " ms"
                         << std::endl;
+              const auto& t = context.query_return.timings;
+              std::cout << "  GPU time: " << t.gpu_execution_time_ms << " ms, CPU time: "
+                        << t.cpu_execution_time_ms << " ms" << std::endl;
+              std::cout << "  Executor queue time: " << t.executor_queue_time_ms << " ms,"
+                        << " Kernel queue time: " << t.kernel_queue_time_ms << " ms,"
+                        << " Compilation queue time: " << t.compilation_queue_time_ms << " ms"
+                        << std::endl;
+              std::cout << "  Kernel time: " << t.kernel_execution_time_ms << " ms, Compilation time: "
+                        << t.compilation_time_ms << " ms" << std::endl;
             }
             continue;
           }
@@ -1420,9 +1428,17 @@ int main(int argc, char** argv) {
           if (print_timing) {
             std::cout << row_count << " rows returned." << std::endl;
             std::cout << "Execution time: " << context.query_return.execution_time_ms
-                      << " ms,"
-                      << " Total time: " << context.query_return.total_time_ms << " ms"
+                      << " ms, Total time: " << context.query_return.total_time_ms << " ms"
                       << std::endl;
+            const auto& t = context.query_return.timings;
+            std::cout << "  GPU time: " << t.gpu_execution_time_ms << " ms, CPU time: "
+                      << t.cpu_execution_time_ms << " ms" << std::endl;
+            std::cout << "  Executor queue time: " << t.executor_queue_time_ms << " ms,"
+                      << " Kernel queue time: " << t.kernel_queue_time_ms << " ms,"
+                      << " Compilation queue time: " << t.compilation_queue_time_ms << " ms"
+                      << std::endl;
+            std::cout << "  Kernel time: " << t.kernel_execution_time_ms << " ms, Compilation time: "
+                      << t.compilation_time_ms << " ms" << std::endl;
           }
         } else {
           (void)backchannel(TURN_OFF, nullptr);

--- a/ThriftHandler/DBHandler.cpp
+++ b/ThriftHandler/DBHandler.cpp
@@ -1250,6 +1250,18 @@ void DBHandler::convertData(TQueryResult& _return,
                             const int32_t first_n,
                             const int32_t at_most_n) {
   _return.execution_time_ms += result.getExecutionTime();
+  if (auto rs = result.getRows()) {
+    if (rs->getDeviceType() == ExecutorDeviceType::GPU) {
+      _return.timings.gpu_execution_time_ms += result.getExecutionTime();
+    } else {
+      _return.timings.cpu_execution_time_ms += result.getExecutionTime();
+    }
+    _return.timings.executor_queue_time_ms += rs->getExecutorQueueTime();
+    _return.timings.kernel_queue_time_ms += rs->getKernelQueueTime();
+    _return.timings.compilation_queue_time_ms += rs->getCompilationQueueTime();
+    _return.timings.kernel_execution_time_ms += rs->getKernelExecutionTime();
+    _return.timings.compilation_time_ms += rs->getCompilationTime();
+  }
   if (result.empty()) {
     return;
   }
@@ -1509,6 +1521,16 @@ void DBHandler::sql_execute_df(TDataFrame& _return,
                                                 : ExecutorDeviceType::GPU;
   _return.execution_time_ms =
       execution_result.getExecutionTime() - result_set->getQueueTime();
+  if (result_set->getDeviceType() == ExecutorDeviceType::GPU) {
+    _return.timings.gpu_execution_time_ms += execution_result.getExecutionTime();
+  } else {
+    _return.timings.cpu_execution_time_ms += execution_result.getExecutionTime();
+  }
+  _return.timings.executor_queue_time_ms += result_set->getExecutorQueueTime();
+  _return.timings.kernel_queue_time_ms += result_set->getKernelQueueTime();
+  _return.timings.compilation_queue_time_ms += result_set->getCompilationQueueTime();
+  _return.timings.kernel_execution_time_ms += result_set->getKernelExecutionTime();
+  _return.timings.compilation_time_ms += result_set->getCompilationTime();
   const auto converter = std::make_unique<ArrowResultSetConverter>(
       result_set,
       data_mgr_,
@@ -8321,7 +8343,18 @@ void DBHandler::executeDdl(
 
     if (!result.empty()) {
       // reduce execution time by the time spent during queue waiting
-      _return.execution_time_ms -= result.getRows()->getQueueTime();
+      const auto rs_ptr = result.getRows();
+      _return.execution_time_ms -= rs_ptr->getQueueTime();
+      if (rs_ptr->getDeviceType() == ExecutorDeviceType::GPU) {
+        _return.timings.gpu_execution_time_ms += result.getExecutionTime();
+      } else {
+        _return.timings.cpu_execution_time_ms += result.getExecutionTime();
+      }
+      _return.timings.executor_queue_time_ms += rs_ptr->getExecutorQueueTime();
+      _return.timings.kernel_queue_time_ms += rs_ptr->getKernelQueueTime();
+      _return.timings.compilation_queue_time_ms += rs_ptr->getCompilationQueueTime();
+      _return.timings.kernel_execution_time_ms += rs_ptr->getKernelExecutionTime();
+      _return.timings.compilation_time_ms += rs_ptr->getCompilationTime();
       convertResultSet(result, *session_ptr, commandStr, _return);
     }
   }

--- a/heavy.thrift
+++ b/heavy.thrift
@@ -180,6 +180,16 @@ enum TArrowTransport {
   WIRE
 }
 
+struct TTimingInfo {
+  1: i64 executor_queue_time_ms;
+  2: i64 kernel_queue_time_ms;
+  3: i64 compilation_queue_time_ms;
+  4: i64 gpu_execution_time_ms;
+  5: i64 cpu_execution_time_ms;
+  6: i64 kernel_execution_time_ms;
+  7: i64 compilation_time_ms;
+}
+
 struct TQueryResult {
   1: TRowSet row_set;
   2: i64 execution_time_ms;
@@ -188,6 +198,7 @@ struct TQueryResult {
   5: string debug;
   6: bool success=true;
   7: TQueryType query_type=TQueryType.UNKNOWN;
+  8: TTimingInfo timings;
 }
 
 struct TDataFrame {
@@ -198,6 +209,7 @@ struct TDataFrame {
   5: i64 execution_time_ms;
   6: i64 arrow_conversion_time_ms;
   7: binary df_buffer;
+  8: TTimingInfo timings;
 }
 
 struct TDBInfo {

--- a/java/heavyaijdbc/src/main/java/ai/heavy/jdbc/HeavyAIArray.java
+++ b/java/heavyaijdbc/src/main/java/ai/heavy/jdbc/HeavyAIArray.java
@@ -200,7 +200,15 @@ public class HeavyAIArray implements java.sql.Array {
     columns.add(new TColumn(idxData, idxNulls));
     columns.add(new TColumn(valuesData, valueNulls));
     TRowSet rowSet = new TRowSet(columnTypes, null, columns, true);
-    TQueryResult result = new TQueryResult(rowSet, 0, 0, "", "", true, TQueryType.READ);
+    TQueryResult result = new TQueryResult(
+            rowSet,
+            0,
+            0,
+            "",
+            "",
+            true,
+            TQueryType.READ,
+            new ai.heavy.thrift.server.TTimingInfo());
     return new HeavyAIResultSet(result, "");
   }
 

--- a/java/heavyaijdbc/src/main/java/ai/heavy/jdbc/HeavyAIDatabaseMetaData.java
+++ b/java/heavyaijdbc/src/main/java/ai/heavy/jdbc/HeavyAIDatabaseMetaData.java
@@ -943,7 +943,14 @@ class HeavyAIDatabaseMetaData implements DatabaseMetaData {
     TRowSet rowSet = new TRowSet(rowDesc, null, columnsList, true);
 
     TQueryResult result = new TQueryResult(
-            rowSet, 0, 0, null, null, true, ai.heavy.thrift.server.TQueryType.UNKNOWN);
+            rowSet,
+            0,
+            0,
+            null,
+            null,
+            true,
+            ai.heavy.thrift.server.TQueryType.UNKNOWN,
+            new ai.heavy.thrift.server.TTimingInfo());
 
     HeavyAIResultSet tab = new HeavyAIResultSet(result, "GetTables");
     return tab;
@@ -1007,7 +1014,14 @@ class HeavyAIDatabaseMetaData implements DatabaseMetaData {
     TRowSet rowSet = new TRowSet(rowDesc, null, columnsList, true);
 
     TQueryResult result = new TQueryResult(
-            rowSet, 0, 0, null, null, true, ai.heavy.thrift.server.TQueryType.UNKNOWN);
+            rowSet,
+            0,
+            0,
+            null,
+            null,
+            true,
+            ai.heavy.thrift.server.TQueryType.UNKNOWN,
+            new ai.heavy.thrift.server.TTimingInfo());
 
     HeavyAIResultSet schemas = new HeavyAIResultSet(result, "getSchemas");
     return schemas;
@@ -1052,7 +1066,14 @@ class HeavyAIDatabaseMetaData implements DatabaseMetaData {
     TRowSet rowSet = new TRowSet(rowDesc, null, columnsList, true);
 
     TQueryResult result = new TQueryResult(
-            rowSet, 0, 0, null, null, true, ai.heavy.thrift.server.TQueryType.UNKNOWN);
+            rowSet,
+            0,
+            0,
+            null,
+            null,
+            true,
+            ai.heavy.thrift.server.TQueryType.UNKNOWN,
+            new ai.heavy.thrift.server.TTimingInfo());
 
     HeavyAIResultSet tab = new HeavyAIResultSet(result, "getTableTypes");
 
@@ -1287,7 +1308,14 @@ class HeavyAIDatabaseMetaData implements DatabaseMetaData {
     TRowSet rowSet = new TRowSet(rowDesc, null, columnsList, true);
 
     TQueryResult result = new TQueryResult(
-            rowSet, 0, 0, null, null, true, ai.heavy.thrift.server.TQueryType.UNKNOWN);
+            rowSet,
+            0,
+            0,
+            null,
+            null,
+            true,
+            ai.heavy.thrift.server.TQueryType.UNKNOWN,
+            new ai.heavy.thrift.server.TTimingInfo());
 
     HeavyAIResultSet cols = new HeavyAIResultSet(result, "getColumns");
     return cols;
@@ -1325,7 +1353,14 @@ class HeavyAIDatabaseMetaData implements DatabaseMetaData {
     }
     TRowSet rowSet = new TRowSet(rowDesc, null, columnsList, true);
     TQueryResult result = new TQueryResult(
-            rowSet, 0, 0, null, null, true, ai.heavy.thrift.server.TQueryType.UNKNOWN);
+            rowSet,
+            0,
+            0,
+            null,
+            null,
+            true,
+            ai.heavy.thrift.server.TQueryType.UNKNOWN,
+            new ai.heavy.thrift.server.TTimingInfo());
     HeavyAIResultSet cols = new HeavyAIResultSet(result, "getColumns");
     return cols;
   }
@@ -1438,7 +1473,14 @@ class HeavyAIDatabaseMetaData implements DatabaseMetaData {
     TRowSet rowSet = new TRowSet(rowDesc, null, columnsList, true);
 
     TQueryResult result = new TQueryResult(
-            rowSet, 0, 0, null, null, true, ai.heavy.thrift.server.TQueryType.UNKNOWN);
+            rowSet,
+            0,
+            0,
+            null,
+            null,
+            true,
+            ai.heavy.thrift.server.TQueryType.UNKNOWN,
+            new ai.heavy.thrift.server.TTimingInfo());
 
     HeavyAIResultSet cols = new HeavyAIResultSet(result, "getPrivileges");
     return cols;
@@ -1709,7 +1751,14 @@ class HeavyAIDatabaseMetaData implements DatabaseMetaData {
     TRowSet rowSet = new TRowSet(rowDesc, null, columnsList, true);
 
     TQueryResult result = new TQueryResult(
-            rowSet, 0, 0, null, null, true, ai.heavy.thrift.server.TQueryType.UNKNOWN);
+            rowSet,
+            0,
+            0,
+            null,
+            null,
+            true,
+            ai.heavy.thrift.server.TQueryType.UNKNOWN,
+            new ai.heavy.thrift.server.TTimingInfo());
 
     HeavyAIResultSet cols = new HeavyAIResultSet(result, "getTypeInfo");
     return cols;

--- a/java/heavyaijdbc/src/main/java/ai/heavy/jdbc/HeavyAIResultSet.java
+++ b/java/heavyaijdbc/src/main/java/ai/heavy/jdbc/HeavyAIResultSet.java
@@ -88,6 +88,14 @@ class HeavyAIResultSet implements java.sql.ResultSet {
     numOfRecords = 0;
   }
 
+  public TTimingInfo getTimings() throws SQLException {
+    checkClosed();
+    if (sqlResult == null || sqlResult.timings == null) {
+      return new TTimingInfo();
+    }
+    return sqlResult.timings;
+  }
+
   @Override
   public boolean next() throws SQLException { // logger.debug("Entered "+ sql );
     checkClosed();
@@ -1331,8 +1339,8 @@ class HeavyAIResultSet implements java.sql.ResultSet {
           elements = new BigDecimal[size];
           for (int i = 0; i < size; ++i) {
             elements[i] = BigDecimal.valueOf(rowSet.columns.get(columnIndex - 1)
-                                                     .data.arr_col.get(offset)
-                                                     .data.real_col.get(i));
+                            .data.arr_col.get(offset)
+                            .data.real_col.get(i));
           }
           break;
         case DOUBLE:

--- a/java/heavyaijdbc/src/main/java/ai/heavy/jdbc/HeavyAIStatement.java
+++ b/java/heavyaijdbc/src/main/java/ai/heavy/jdbc/HeavyAIStatement.java
@@ -199,6 +199,14 @@ public class HeavyAIStatement implements java.sql.Statement {
     return (int) sqlResult.execution_time_ms;
   }
 
+  // expose detailed timing breakdowns
+  public TTimingInfo getQueryTimings() throws SQLException {
+    if (sqlResult == null || sqlResult.timings == null) {
+      return new TTimingInfo();
+    }
+    return sqlResult.timings;
+  }
+
   @Override
   public void setQueryTimeout(int seconds)
           throws SQLException { // logger.debug("Entered");


### PR DESCRIPTION
## Summary
- add `getQueryTimings` to JDBC `HeavyAIStatement`
- expose timing info via `HeavyAIResultSet.getTimings`

## Testing
- `./scripts/clang-format-diff HEAD` *(fails: docker: command not found)*
- `mvn -q -f java/heavyaijdbc/pom.xml test` *(fails: plugin com.github.gzm55.maven:project-settings-extension:0.1.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6869901b1a74832fbfaf6d7e7930dba8