### PR TITLE
Track and display SQL parsing time

### DIFF
--- a/QueryEngine/Descriptors/RelAlgExecutionDescriptor.cpp
+++ b/QueryEngine/Descriptors/RelAlgExecutionDescriptor.cpp
@@ -27,6 +27,7 @@ ExecutionResult::ExecutionResult()
     : filter_push_down_enabled_(false)
     , success_(true)
     , execution_time_ms_(0)
+    , parsing_time_ms_(0)
     , type_(QueryResult) {}
 
 ExecutionResult::ExecutionResult(const std::shared_ptr<ResultSet>& rows,
@@ -36,6 +37,7 @@ ExecutionResult::ExecutionResult(const std::shared_ptr<ResultSet>& rows,
     , filter_push_down_enabled_(false)
     , success_(true)
     , execution_time_ms_(0)
+    , parsing_time_ms_(0)
     , type_(QueryResult) {}
 
 ExecutionResult::ExecutionResult(ResultSetPtr&& result,
@@ -45,6 +47,7 @@ ExecutionResult::ExecutionResult(ResultSetPtr&& result,
     , filter_push_down_enabled_(false)
     , success_(true)
     , execution_time_ms_(0)
+    , parsing_time_ms_(0)
     , type_(QueryResult) {}
 
 ExecutionResult::ExecutionResult(const ExecutionResult& that)
@@ -53,6 +56,7 @@ ExecutionResult::ExecutionResult(const ExecutionResult& that)
     , filter_push_down_enabled_(that.filter_push_down_enabled_)
     , success_(that.success_)
     , execution_time_ms_(that.execution_time_ms_)
+    , parsing_time_ms_(that.parsing_time_ms_)
     , type_(that.type_) {
   if (!pushed_down_filter_info_.empty() ||
       (filter_push_down_enabled_ && pushed_down_filter_info_.empty())) {
@@ -67,6 +71,7 @@ ExecutionResult::ExecutionResult(ExecutionResult&& that)
     , filter_push_down_enabled_(std::move(that.filter_push_down_enabled_))
     , success_(that.success_)
     , execution_time_ms_(that.execution_time_ms_)
+    , parsing_time_ms_(that.parsing_time_ms_)
     , type_(that.type_) {
   if (!pushed_down_filter_info_.empty() ||
       (filter_push_down_enabled_ && pushed_down_filter_info_.empty())) {
@@ -82,6 +87,7 @@ ExecutionResult::ExecutionResult(
     , filter_push_down_enabled_(filter_push_down_enabled)
     , success_(true)
     , execution_time_ms_(0)
+    , parsing_time_ms_(0)
     , type_(QueryResult) {}
 
 ExecutionResult& ExecutionResult::operator=(const ExecutionResult& that) {
@@ -95,6 +101,7 @@ ExecutionResult& ExecutionResult::operator=(const ExecutionResult& that) {
   targets_meta_ = that.targets_meta_;
   success_ = that.success_;
   execution_time_ms_ = that.execution_time_ms_;
+  parsing_time_ms_ = that.parsing_time_ms_;
   type_ = that.type_;
   return *this;
 }

--- a/QueryEngine/Descriptors/RelAlgExecutionDescriptor.h
+++ b/QueryEngine/Descriptors/RelAlgExecutionDescriptor.h
@@ -79,6 +79,8 @@ class ExecutionResult {
   void addExecutionTime(int64_t execution_time_ms) {
     execution_time_ms_ += execution_time_ms;
   }
+  int64_t getParsingTime() const { return parsing_time_ms_; }
+  void addParsingTime(int64_t parsing_time_ms) { parsing_time_ms_ += parsing_time_ms; }
 
  private:
   ResultSetPtr result_;
@@ -90,6 +92,7 @@ class ExecutionResult {
 
   bool success_;
   uint64_t execution_time_ms_;
+  uint64_t parsing_time_ms_;
   RType type_;
 };
 

--- a/SQLFrontend/heavysql.cpp
+++ b/SQLFrontend/heavysql.cpp
@@ -1087,8 +1087,7 @@ void print_status(ClientContext& context) {
   const std::string deployment_type = (is_cluster) ? "Cluster" : "Server";
 
   tss << std::left << std::setfill(' ') << std::setw(lhs_width);
-  tss << deployment_type + " Version"
-      << ": " << agg_version << " " << edition;
+  tss << deployment_type + " Version" << ": " << agg_version << " " << edition;
   tss << std::endl;
 
   const auto& host_id = context.cluster_status[0].host_id;
@@ -1117,18 +1116,15 @@ void print_status(ClientContext& context) {
     tss << "--------------------------------------------------" << std::endl;
 
     tss << std::left << std::setfill(' ') << std::setw(lhs_width);
-    tss << process_role + " Name"
-        << ": " << node->host_name << std::endl;
+    tss << process_role + " Name" << ": " << node->host_name << std::endl;
 
     tss << std::left << std::setfill(' ') << std::setw(lhs_width);
-    tss << process_role + " Start Time"
-        << ": " << buf << " : " << tm_ptr->tm_hour << ":" << tm_ptr->tm_min << ":"
-        << tm_ptr->tm_sec << std::endl;
+    tss << process_role + " Start Time" << ": " << buf << " : " << tm_ptr->tm_hour << ":"
+        << tm_ptr->tm_min << ":" << tm_ptr->tm_sec << std::endl;
 
     if (agg_version != node->version) {
       tss << std::left << std::setfill(' ') << std::setw(lhs_width);
-      tss << process_role + " Version "
-          << ": " << node->version << std::endl
+      tss << process_role + " Version " << ": " << node->version << std::endl
           << "\033[31m*** Version mismatch! ***\033[0m Please make "
              "sure All leaves, Aggregator and String Dictionary are running "
              "the same version of HeavyDB."
@@ -1382,17 +1378,20 @@ int main(int argc, char** argv) {
             }
             if (print_timing) {
               std::cout << "Execution time: " << context.query_return.execution_time_ms
-                        << " ms, Total time: " << context.query_return.total_time_ms << " ms"
-                        << std::endl;
+                        << " ms, Total time: " << context.query_return.total_time_ms
+                        << " ms" << std::endl;
               const auto& t = context.query_return.timings;
-              std::cout << "  GPU time: " << t.gpu_execution_time_ms << " ms, CPU time: "
-                        << t.cpu_execution_time_ms << " ms" << std::endl;
+              std::cout << "  GPU time: " << t.gpu_execution_time_ms
+                        << " ms, CPU time: " << t.cpu_execution_time_ms << " ms"
+                        << std::endl;
               std::cout << "  Executor queue time: " << t.executor_queue_time_ms << " ms,"
                         << " Kernel queue time: " << t.kernel_queue_time_ms << " ms,"
-                        << " Compilation queue time: " << t.compilation_queue_time_ms << " ms"
+                        << " Compilation queue time: " << t.compilation_queue_time_ms
+                        << " ms" << std::endl;
+              std::cout << "  Kernel time: " << t.kernel_execution_time_ms
+                        << " ms, Compilation time: " << t.compilation_time_ms
+                        << " ms, Parsing time: " << t.parsing_time_ms << " ms"
                         << std::endl;
-              std::cout << "  Kernel time: " << t.kernel_execution_time_ms << " ms, Compilation time: "
-                        << t.compilation_time_ms << " ms" << std::endl;
             }
             continue;
           }
@@ -1428,17 +1427,19 @@ int main(int argc, char** argv) {
           if (print_timing) {
             std::cout << row_count << " rows returned." << std::endl;
             std::cout << "Execution time: " << context.query_return.execution_time_ms
-                      << " ms, Total time: " << context.query_return.total_time_ms << " ms"
-                      << std::endl;
+                      << " ms, Total time: " << context.query_return.total_time_ms
+                      << " ms" << std::endl;
             const auto& t = context.query_return.timings;
-            std::cout << "  GPU time: " << t.gpu_execution_time_ms << " ms, CPU time: "
-                      << t.cpu_execution_time_ms << " ms" << std::endl;
+            std::cout << "  GPU time: " << t.gpu_execution_time_ms
+                      << " ms, CPU time: " << t.cpu_execution_time_ms << " ms"
+                      << std::endl;
             std::cout << "  Executor queue time: " << t.executor_queue_time_ms << " ms,"
                       << " Kernel queue time: " << t.kernel_queue_time_ms << " ms,"
-                      << " Compilation queue time: " << t.compilation_queue_time_ms << " ms"
-                      << std::endl;
-            std::cout << "  Kernel time: " << t.kernel_execution_time_ms << " ms, Compilation time: "
-                      << t.compilation_time_ms << " ms" << std::endl;
+                      << " Compilation queue time: " << t.compilation_queue_time_ms
+                      << " ms" << std::endl;
+            std::cout << "  Kernel time: " << t.kernel_execution_time_ms
+                      << " ms, Compilation time: " << t.compilation_time_ms
+                      << " ms, Parsing time: " << t.parsing_time_ms << " ms" << std::endl;
           }
         } else {
           (void)backchannel(TURN_OFF, nullptr);

--- a/ThriftHandler/DBHandler.cpp
+++ b/ThriftHandler/DBHandler.cpp
@@ -83,7 +83,6 @@
 #include "Shared/scope.h"
 #include "UdfCompiler/UdfCompiler.h"
 
-
 #ifdef HAVE_AWS_S3
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
 #endif
@@ -1262,6 +1261,7 @@ void DBHandler::convertData(TQueryResult& _return,
     _return.timings.kernel_execution_time_ms += rs->getKernelExecutionTime();
     _return.timings.compilation_time_ms += rs->getCompilationTime();
   }
+  _return.timings.parsing_time_ms += result.getParsingTime();
   if (result.empty()) {
     return;
   }
@@ -1531,6 +1531,7 @@ void DBHandler::sql_execute_df(TDataFrame& _return,
   _return.timings.compilation_queue_time_ms += result_set->getCompilationQueueTime();
   _return.timings.kernel_execution_time_ms += result_set->getKernelExecutionTime();
   _return.timings.compilation_time_ms += result_set->getCompilationTime();
+  _return.timings.parsing_time_ms += execution_result.getParsingTime();
   const auto converter = std::make_unique<ArrowResultSetConverter>(
       result_set,
       data_mgr_,
@@ -6704,12 +6705,13 @@ void DBHandler::sql_execute_impl(ExecutionResult& _return,
     check_read_only("insert_into_table");
 
     std::string query_ra;
+    TPlanResult parse_result;
     _return.addExecutionTime(measure<>::execution([&]() {
-      TPlanResult result;
-      std::tie(result, locks) =
+      std::tie(parse_result, locks) =
           parse_to_ra(query_state_proxy, query_str, {}, false, system_parameters_);
-      query_ra = result.plan_result;
+      query_ra = parse_result.plan_result;
     }));
+    _return.addParsingTime(parse_result.execution_time_ms);
     rapidjson::Document ddl_query;
     ddl_query.Parse(query_ra);
     CHECK(ddl_query.HasMember("payload"));
@@ -6725,12 +6727,13 @@ void DBHandler::sql_execute_impl(ExecutionResult& _return,
     check_read_only("create_table_as");
 
     std::string query_ra;
+    TPlanResult parse_result;
     _return.addExecutionTime(measure<>::execution([&]() {
-      TPlanResult result;
-      std::tie(result, locks) =
+      std::tie(parse_result, locks) =
           parse_to_ra(query_state_proxy, query_str, {}, false, system_parameters_);
-      query_ra = result.plan_result;
+      query_ra = parse_result.plan_result;
     }));
+    _return.addParsingTime(parse_result.execution_time_ms);
     if (query_ra.size()) {
       rapidjson::Document ddl_query;
       ddl_query.Parse(query_ra);
@@ -6746,12 +6749,13 @@ void DBHandler::sql_execute_impl(ExecutionResult& _return,
   } else if (pw.getDMLType() == ParserWrapper::DMLType::Insert) {
     check_read_only("insert_into_table");
     std::string query_ra;
+    TPlanResult parse_result;
     _return.addExecutionTime(measure<>::execution([&]() {
-      TPlanResult result;
-      std::tie(result, locks) =
+      std::tie(parse_result, locks) =
           parse_to_ra(query_state_proxy, query_str, {}, false, system_parameters_);
-      query_ra = result.plan_result;
+      query_ra = parse_result.plan_result;
     }));
+    _return.addParsingTime(parse_result.execution_time_ms);
     rapidjson::Document ddl_query;
     ddl_query.Parse(query_ra);
     CHECK(ddl_query.HasMember("payload"));
@@ -6771,12 +6775,13 @@ void DBHandler::sql_execute_impl(ExecutionResult& _return,
     }
 
     std::string query_ra;
+    TPlanResult parse_result;
     _return.addExecutionTime(measure<>::execution([&]() {
-      TPlanResult result;
-      std::tie(result, locks) =
+      std::tie(parse_result, locks) =
           parse_to_ra(query_state_proxy, query_str, {}, false, system_parameters_);
-      query_ra = result.plan_result;
+      query_ra = parse_result.plan_result;
     }));
+    _return.addParsingTime(parse_result.execution_time_ms);
     rapidjson::Document ddl_query;
     ddl_query.Parse(query_ra);
     CHECK(ddl_query.HasMember("payload"));
@@ -6844,12 +6849,13 @@ void DBHandler::sql_execute_impl(ExecutionResult& _return,
 
   } else if (pw.is_ddl) {
     std::string query_ra;
+    TPlanResult parse_result;
     _return.addExecutionTime(measure<>::execution([&]() {
-      TPlanResult result;
-      std::tie(result, locks) =
+      std::tie(parse_result, locks) =
           parse_to_ra(query_state_proxy, query_str, {}, false, system_parameters_);
-      query_ra = result.plan_result;
+      query_ra = parse_result.plan_result;
     }));
+    _return.addParsingTime(parse_result.execution_time_ms);
     executeDdl(_return, query_ra, session_ptr);
     return;
 
@@ -6873,12 +6879,13 @@ void DBHandler::sql_execute_impl(ExecutionResult& _return,
 
     std::string query_ra = query_str;
     if (use_calcite) {
+      TPlanResult parse_result;
       _return.addExecutionTime(measure<>::execution([&]() {
-        TPlanResult result;
-        std::tie(result, locks) =
+        std::tie(parse_result, locks) =
             parse_to_ra(query_state_proxy, query_str, {}, true, system_parameters_);
-        query_ra = result.plan_result;
+        query_ra = parse_result.plan_result;
       }));
+      _return.addParsingTime(parse_result.execution_time_ms);
     }
     std::string query_ra_calcite_explain;
     ExplainInfo explain(query_str);
@@ -6889,10 +6896,10 @@ void DBHandler::sql_execute_impl(ExecutionResult& _return,
         return;
       }
       CHECK(!locks.empty());
-      query_ra_calcite_explain =
-          parse_to_ra(
-              query_state_proxy, explain.ActualQuery(), {}, false, system_parameters_)
-              .first.plan_result;
+      auto parse_pair = parse_to_ra(
+          query_state_proxy, explain.ActualQuery(), {}, false, system_parameters_);
+      _return.addParsingTime(parse_pair.first.execution_time_ms);
+      query_ra_calcite_explain = parse_pair.first.plan_result;
     }
     std::vector<PushedDownFilterInfo> filter_push_down_requests;
     auto submitted_time_str = query_state_proxy->getQuerySubmittedTime();
@@ -6950,12 +6957,13 @@ void DBHandler::sql_execute_impl(ExecutionResult& _return,
                     filter_push_down_info_for_request.input_next = req.input_next;
                     filter_push_down_info.push_back(filter_push_down_info_for_request);
                   }
-                  query_ra = parse_to_ra(query_state_proxy,
-                                         query_str,
-                                         filter_push_down_info,
-                                         false,
-                                         system_parameters_)
-                                 .first.plan_result;
+                  auto parse_pair = parse_to_ra(query_state_proxy,
+                                                query_str,
+                                                filter_push_down_info,
+                                                false,
+                                                system_parameters_);
+                  _return.addParsingTime(parse_pair.first.execution_time_ms);
+                  query_ra = parse_pair.first.plan_result;
                   _return.updateResultSet(query_ra, ExecutionResult::Explanation);
                 }
               } else {
@@ -7021,14 +7029,17 @@ void DBHandler::execute_rel_alg_with_filter_push_down(
     filter_push_down_info.push_back(filter_push_down_info_for_request);
   }
   // deriving the new relational algebra plan with respect to the pushed down filters
+  TPlanResult parse_result;
   _return.addExecutionTime(measure<>::execution([&]() {
-    query_ra = parse_to_ra(query_state_proxy,
-                           query_state_proxy->getQueryStr(),
-                           filter_push_down_info,
-                           false,
-                           system_parameters_)
-                   .first.plan_result;
+    auto parse_pair = parse_to_ra(query_state_proxy,
+                                  query_state_proxy->getQueryStr(),
+                                  filter_push_down_info,
+                                  false,
+                                  system_parameters_);
+    parse_result = parse_pair.first;
+    query_ra = parse_result.plan_result;
   }));
+  _return.addParsingTime(parse_result.execution_time_ms);
 
   // execute the new relational algebra plan:
   auto explain_info = ExplainInfo(ExplainInfo::ExplainType::None);
@@ -7782,7 +7793,6 @@ void DBHandler::shutdown() {
     render_handler_->shutdown();
   }
 
-
   Catalog_Namespace::SysCatalog::destroy();
 }
 
@@ -8355,6 +8365,7 @@ void DBHandler::executeDdl(
       _return.timings.compilation_queue_time_ms += rs_ptr->getCompilationQueueTime();
       _return.timings.kernel_execution_time_ms += rs_ptr->getKernelExecutionTime();
       _return.timings.compilation_time_ms += rs_ptr->getCompilationTime();
+      _return.timings.parsing_time_ms += result.getParsingTime();
       convertResultSet(result, *session_ptr, commandStr, _return);
     }
   }

--- a/ThriftHandler/DBHandler.cpp
+++ b/ThriftHandler/DBHandler.cpp
@@ -6460,6 +6460,7 @@ std::vector<PushedDownFilterInfo> DBHandler::execute_rel_alg(
       g_running_query_interrupt_freq,
       g_pending_query_interrupt_freq,
       g_optimize_cuda_block_and_grid_sizes};
+  const auto parsing_time_ms = _return.getParsingTime();
   auto execution_time_ms =
       _return.getExecutionTime() + measure<>::execution([&]() {
         _return = ra_executor.executeRelAlgQuery(
@@ -6471,6 +6472,7 @@ std::vector<PushedDownFilterInfo> DBHandler::execute_rel_alg(
     execution_time_ms -= rs->getQueueTime();
   }
   _return.setExecutionTime(execution_time_ms);
+  _return.addParsingTime(parsing_time_ms);
   const auto& filter_push_down_info = _return.getPushedDownFilterInfo();
   if (!filter_push_down_info.empty()) {
     return filter_push_down_info;

--- a/ThriftHandler/DBHandler.cpp
+++ b/ThriftHandler/DBHandler.cpp
@@ -6706,12 +6706,13 @@ void DBHandler::sql_execute_impl(ExecutionResult& _return,
 
     std::string query_ra;
     TPlanResult parse_result;
-    _return.addExecutionTime(measure<>::execution([&]() {
+    auto parse_time_ms = measure<>::execution([&]() {
       std::tie(parse_result, locks) =
           parse_to_ra(query_state_proxy, query_str, {}, false, system_parameters_);
       query_ra = parse_result.plan_result;
-    }));
-    _return.addParsingTime(parse_result.execution_time_ms);
+    });
+    _return.addExecutionTime(parse_time_ms);
+    _return.addParsingTime(parse_time_ms);
     rapidjson::Document ddl_query;
     ddl_query.Parse(query_ra);
     CHECK(ddl_query.HasMember("payload"));
@@ -6728,12 +6729,13 @@ void DBHandler::sql_execute_impl(ExecutionResult& _return,
 
     std::string query_ra;
     TPlanResult parse_result;
-    _return.addExecutionTime(measure<>::execution([&]() {
+    auto parse_time_ms = measure<>::execution([&]() {
       std::tie(parse_result, locks) =
           parse_to_ra(query_state_proxy, query_str, {}, false, system_parameters_);
       query_ra = parse_result.plan_result;
-    }));
-    _return.addParsingTime(parse_result.execution_time_ms);
+    });
+    _return.addExecutionTime(parse_time_ms);
+    _return.addParsingTime(parse_time_ms);
     if (query_ra.size()) {
       rapidjson::Document ddl_query;
       ddl_query.Parse(query_ra);
@@ -6750,12 +6752,13 @@ void DBHandler::sql_execute_impl(ExecutionResult& _return,
     check_read_only("insert_into_table");
     std::string query_ra;
     TPlanResult parse_result;
-    _return.addExecutionTime(measure<>::execution([&]() {
+    auto parse_time_ms = measure<>::execution([&]() {
       std::tie(parse_result, locks) =
           parse_to_ra(query_state_proxy, query_str, {}, false, system_parameters_);
       query_ra = parse_result.plan_result;
-    }));
-    _return.addParsingTime(parse_result.execution_time_ms);
+    });
+    _return.addExecutionTime(parse_time_ms);
+    _return.addParsingTime(parse_time_ms);
     rapidjson::Document ddl_query;
     ddl_query.Parse(query_ra);
     CHECK(ddl_query.HasMember("payload"));
@@ -6776,12 +6779,13 @@ void DBHandler::sql_execute_impl(ExecutionResult& _return,
 
     std::string query_ra;
     TPlanResult parse_result;
-    _return.addExecutionTime(measure<>::execution([&]() {
+    auto parse_time_ms = measure<>::execution([&]() {
       std::tie(parse_result, locks) =
           parse_to_ra(query_state_proxy, query_str, {}, false, system_parameters_);
       query_ra = parse_result.plan_result;
-    }));
-    _return.addParsingTime(parse_result.execution_time_ms);
+    });
+    _return.addExecutionTime(parse_time_ms);
+    _return.addParsingTime(parse_time_ms);
     rapidjson::Document ddl_query;
     ddl_query.Parse(query_ra);
     CHECK(ddl_query.HasMember("payload"));
@@ -6850,12 +6854,13 @@ void DBHandler::sql_execute_impl(ExecutionResult& _return,
   } else if (pw.is_ddl) {
     std::string query_ra;
     TPlanResult parse_result;
-    _return.addExecutionTime(measure<>::execution([&]() {
+    auto parse_time_ms = measure<>::execution([&]() {
       std::tie(parse_result, locks) =
           parse_to_ra(query_state_proxy, query_str, {}, false, system_parameters_);
       query_ra = parse_result.plan_result;
-    }));
-    _return.addParsingTime(parse_result.execution_time_ms);
+    });
+    _return.addExecutionTime(parse_time_ms);
+    _return.addParsingTime(parse_time_ms);
     executeDdl(_return, query_ra, session_ptr);
     return;
 
@@ -6880,12 +6885,13 @@ void DBHandler::sql_execute_impl(ExecutionResult& _return,
     std::string query_ra = query_str;
     if (use_calcite) {
       TPlanResult parse_result;
-      _return.addExecutionTime(measure<>::execution([&]() {
+      auto parse_time_ms = measure<>::execution([&]() {
         std::tie(parse_result, locks) =
             parse_to_ra(query_state_proxy, query_str, {}, true, system_parameters_);
         query_ra = parse_result.plan_result;
-      }));
-      _return.addParsingTime(parse_result.execution_time_ms);
+      });
+      _return.addExecutionTime(parse_time_ms);
+      _return.addParsingTime(parse_time_ms);
     }
     std::string query_ra_calcite_explain;
     ExplainInfo explain(query_str);
@@ -6896,9 +6902,12 @@ void DBHandler::sql_execute_impl(ExecutionResult& _return,
         return;
       }
       CHECK(!locks.empty());
-      auto parse_pair = parse_to_ra(
-          query_state_proxy, explain.ActualQuery(), {}, false, system_parameters_);
-      _return.addParsingTime(parse_pair.first.execution_time_ms);
+      std::pair<TPlanResult, lockmgr::LockedTableDescriptors> parse_pair;
+      auto parse_time_ms = measure<>::execution([&]() {
+        parse_pair = parse_to_ra(
+            query_state_proxy, explain.ActualQuery(), {}, false, system_parameters_);
+      });
+      _return.addParsingTime(parse_time_ms);
       query_ra_calcite_explain = parse_pair.first.plan_result;
     }
     std::vector<PushedDownFilterInfo> filter_push_down_requests;
@@ -6957,12 +6966,15 @@ void DBHandler::sql_execute_impl(ExecutionResult& _return,
                     filter_push_down_info_for_request.input_next = req.input_next;
                     filter_push_down_info.push_back(filter_push_down_info_for_request);
                   }
-                  auto parse_pair = parse_to_ra(query_state_proxy,
-                                                query_str,
-                                                filter_push_down_info,
-                                                false,
-                                                system_parameters_);
-                  _return.addParsingTime(parse_pair.first.execution_time_ms);
+                  std::pair<TPlanResult, lockmgr::LockedTableDescriptors> parse_pair;
+                  auto parse_time_ms = measure<>::execution([&]() {
+                    parse_pair = parse_to_ra(query_state_proxy,
+                                             query_str,
+                                             filter_push_down_info,
+                                             false,
+                                             system_parameters_);
+                  });
+                  _return.addParsingTime(parse_time_ms);
                   query_ra = parse_pair.first.plan_result;
                   _return.updateResultSet(query_ra, ExecutionResult::Explanation);
                 }
@@ -7030,7 +7042,7 @@ void DBHandler::execute_rel_alg_with_filter_push_down(
   }
   // deriving the new relational algebra plan with respect to the pushed down filters
   TPlanResult parse_result;
-  _return.addExecutionTime(measure<>::execution([&]() {
+  auto parse_time_ms = measure<>::execution([&]() {
     auto parse_pair = parse_to_ra(query_state_proxy,
                                   query_state_proxy->getQueryStr(),
                                   filter_push_down_info,
@@ -7038,8 +7050,9 @@ void DBHandler::execute_rel_alg_with_filter_push_down(
                                   system_parameters_);
     parse_result = parse_pair.first;
     query_ra = parse_result.plan_result;
-  }));
-  _return.addParsingTime(parse_result.execution_time_ms);
+  });
+  _return.addExecutionTime(parse_time_ms);
+  _return.addParsingTime(parse_time_ms);
 
   // execute the new relational algebra plan:
   auto explain_info = ExplainInfo(ExplainInfo::ExplainType::None);

--- a/heavy.thrift
+++ b/heavy.thrift
@@ -188,6 +188,7 @@ struct TTimingInfo {
   5: i64 cpu_execution_time_ms;
   6: i64 kernel_execution_time_ms;
   7: i64 compilation_time_ms;
+  8: i64 parsing_time_ms;
 }
 
 struct TQueryResult {


### PR DESCRIPTION
## Summary
- track query parsing duration on the server
- include parsing time in client timing display

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68af9e2f65bc832fa6bded7a707281de