### PR TITLE
Add optimizer timing to query diagnostics

### DIFF
--- a/QueryEngine/Descriptors/RelAlgExecutionDescriptor.cpp
+++ b/QueryEngine/Descriptors/RelAlgExecutionDescriptor.cpp
@@ -28,6 +28,7 @@ ExecutionResult::ExecutionResult()
     , success_(true)
     , execution_time_ms_(0)
     , parsing_time_ms_(0)
+    , optimization_time_ms_(0)
     , type_(QueryResult) {}
 
 ExecutionResult::ExecutionResult(const std::shared_ptr<ResultSet>& rows,
@@ -38,6 +39,7 @@ ExecutionResult::ExecutionResult(const std::shared_ptr<ResultSet>& rows,
     , success_(true)
     , execution_time_ms_(0)
     , parsing_time_ms_(0)
+    , optimization_time_ms_(0)
     , type_(QueryResult) {}
 
 ExecutionResult::ExecutionResult(ResultSetPtr&& result,
@@ -48,6 +50,7 @@ ExecutionResult::ExecutionResult(ResultSetPtr&& result,
     , success_(true)
     , execution_time_ms_(0)
     , parsing_time_ms_(0)
+    , optimization_time_ms_(0)
     , type_(QueryResult) {}
 
 ExecutionResult::ExecutionResult(const ExecutionResult& that)
@@ -57,6 +60,7 @@ ExecutionResult::ExecutionResult(const ExecutionResult& that)
     , success_(that.success_)
     , execution_time_ms_(that.execution_time_ms_)
     , parsing_time_ms_(that.parsing_time_ms_)
+    , optimization_time_ms_(that.optimization_time_ms_)
     , type_(that.type_) {
   if (!pushed_down_filter_info_.empty() ||
       (filter_push_down_enabled_ && pushed_down_filter_info_.empty())) {
@@ -72,6 +76,7 @@ ExecutionResult::ExecutionResult(ExecutionResult&& that)
     , success_(that.success_)
     , execution_time_ms_(that.execution_time_ms_)
     , parsing_time_ms_(that.parsing_time_ms_)
+    , optimization_time_ms_(that.optimization_time_ms_)
     , type_(that.type_) {
   if (!pushed_down_filter_info_.empty() ||
       (filter_push_down_enabled_ && pushed_down_filter_info_.empty())) {
@@ -88,6 +93,7 @@ ExecutionResult::ExecutionResult(
     , success_(true)
     , execution_time_ms_(0)
     , parsing_time_ms_(0)
+    , optimization_time_ms_(0)
     , type_(QueryResult) {}
 
 ExecutionResult& ExecutionResult::operator=(const ExecutionResult& that) {
@@ -102,6 +108,7 @@ ExecutionResult& ExecutionResult::operator=(const ExecutionResult& that) {
   success_ = that.success_;
   execution_time_ms_ = that.execution_time_ms_;
   parsing_time_ms_ = that.parsing_time_ms_;
+  optimization_time_ms_ = that.optimization_time_ms_;
   type_ = that.type_;
   return *this;
 }

--- a/QueryEngine/Descriptors/RelAlgExecutionDescriptor.h
+++ b/QueryEngine/Descriptors/RelAlgExecutionDescriptor.h
@@ -82,6 +82,11 @@ class ExecutionResult {
   int64_t getParsingTime() const { return parsing_time_ms_; }
   void addParsingTime(int64_t parsing_time_ms) { parsing_time_ms_ += parsing_time_ms; }
 
+  int64_t getOptimizationTime() const { return optimization_time_ms_; }
+  void addOptimizationTime(int64_t optimization_time_ms) {
+    optimization_time_ms_ += optimization_time_ms;
+  }
+
  private:
   ResultSetPtr result_;
   std::vector<TargetMetaInfo> targets_meta_;
@@ -93,6 +98,7 @@ class ExecutionResult {
   bool success_;
   uint64_t execution_time_ms_;
   uint64_t parsing_time_ms_;
+  uint64_t optimization_time_ms_;
   RType type_;
 };
 

--- a/QueryEngine/RelAlgDag.cpp
+++ b/QueryEngine/RelAlgDag.cpp
@@ -3726,17 +3726,21 @@ std::unique_ptr<RelAlgDag> RelAlgDagBuilder::build(const rapidjson::Value& query
 }
 
 void RelAlgDagBuilder::optimizeDag(RelAlgDag& rel_alg_dag) {
-  auto optimize_start = timer_start();
-  ScopeGuard log_timer = [&optimize_start]() {
-    VLOG(1) << "Optimize RelAlgDag took: " << timer_stop(optimize_start) << " ms";
-  };
   auto const build_state = rel_alg_dag.getBuildState();
   if (build_state == RelAlgDag::BuildState::kBuiltOptimized) {
+    setOptimizationTime(rel_alg_dag, 0);
     return;
   }
 
   CHECK(build_state == RelAlgDag::BuildState::kBuiltNotOptimized)
       << static_cast<int>(build_state);
+
+  auto optimize_start = timer_start();
+  ScopeGuard log_timer = [&rel_alg_dag, &optimize_start]() {
+    auto opt_time = timer_stop(optimize_start);
+    VLOG(1) << "Optimize RelAlgDag took: " << opt_time << " ms";
+    setOptimizationTime(rel_alg_dag, opt_time);
+  };
 
   auto& nodes = getNodes(rel_alg_dag);
   auto& subqueries = getSubqueries(rel_alg_dag);

--- a/QueryEngine/RelAlgDag.h
+++ b/QueryEngine/RelAlgDag.h
@@ -3245,6 +3245,8 @@ class RelAlgDag : public boost::noncopyable {
     return subqueries_;
   }
 
+  int64_t getOptimizationTime() const { return optimize_time_ms_; }
+
   // todo(yoonmin): simplify and improve query register logic
   void registerQueryHints(std::shared_ptr<RelAlgNode> node,
                           Hints* hints_delivered,
@@ -3787,6 +3789,7 @@ class RelAlgDag : public boost::noncopyable {
 
  private:
   BuildState build_state_;
+  int64_t optimize_time_ms_{0};
 
   std::vector<std::shared_ptr<RelAlgNode>> nodes_;
   std::vector<std::shared_ptr<RexSubQuery>> subqueries_;
@@ -3829,6 +3832,10 @@ struct RelAlgDagModifier {
   static void setBuildState(RelAlgDag& rel_alg_dag,
                             const RelAlgDag::BuildState build_state) {
     rel_alg_dag.build_state_ = build_state;
+  }
+
+  static void setOptimizationTime(RelAlgDag& rel_alg_dag, const int64_t time_ms) {
+    rel_alg_dag.optimize_time_ms_ = time_ms;
   }
 };
 

--- a/SQLFrontend/heavysql.cpp
+++ b/SQLFrontend/heavysql.cpp
@@ -1390,7 +1390,8 @@ int main(int argc, char** argv) {
                         << " ms" << std::endl;
               std::cout << "  Kernel time: " << t.kernel_execution_time_ms
                         << " ms, Compilation time: " << t.compilation_time_ms
-                        << " ms, Parsing time: " << t.parsing_time_ms << " ms"
+                        << " ms, Parsing time: " << t.parsing_time_ms
+                        << " ms, Optimizer time: " << t.optimizer_time_ms << " ms"
                         << std::endl;
             }
             continue;
@@ -1439,7 +1440,9 @@ int main(int argc, char** argv) {
                       << " ms" << std::endl;
             std::cout << "  Kernel time: " << t.kernel_execution_time_ms
                       << " ms, Compilation time: " << t.compilation_time_ms
-                      << " ms, Parsing time: " << t.parsing_time_ms << " ms" << std::endl;
+                      << " ms, Parsing time: " << t.parsing_time_ms
+                      << " ms, Optimizer time: " << t.optimizer_time_ms << " ms"
+                      << std::endl;
           }
         } else {
           (void)backchannel(TURN_OFF, nullptr);

--- a/ThriftHandler/DBHandler.cpp
+++ b/ThriftHandler/DBHandler.cpp
@@ -1262,6 +1262,7 @@ void DBHandler::convertData(TQueryResult& _return,
     _return.timings.compilation_time_ms += rs->getCompilationTime();
   }
   _return.timings.parsing_time_ms += result.getParsingTime();
+  _return.timings.optimizer_time_ms += result.getOptimizationTime();
   if (result.empty()) {
     return;
   }
@@ -1532,6 +1533,7 @@ void DBHandler::sql_execute_df(TDataFrame& _return,
   _return.timings.kernel_execution_time_ms += result_set->getKernelExecutionTime();
   _return.timings.compilation_time_ms += result_set->getCompilationTime();
   _return.timings.parsing_time_ms += execution_result.getParsingTime();
+  _return.timings.optimizer_time_ms += execution_result.getOptimizationTime();
   const auto converter = std::make_unique<ArrowResultSetConverter>(
       result_set,
       data_mgr_,
@@ -6461,6 +6463,7 @@ std::vector<PushedDownFilterInfo> DBHandler::execute_rel_alg(
       g_pending_query_interrupt_freq,
       g_optimize_cuda_block_and_grid_sizes};
   const auto parsing_time_ms = _return.getParsingTime();
+  const auto optimizer_time_ms = _return.getOptimizationTime();
   auto execution_time_ms =
       _return.getExecutionTime() + measure<>::execution([&]() {
         _return = ra_executor.executeRelAlgQuery(
@@ -6473,6 +6476,8 @@ std::vector<PushedDownFilterInfo> DBHandler::execute_rel_alg(
   }
   _return.setExecutionTime(execution_time_ms);
   _return.addParsingTime(parsing_time_ms);
+  _return.addOptimizationTime(optimizer_time_ms +
+                              ra_executor.getRelAlgDag()->getOptimizationTime());
   const auto& filter_push_down_info = _return.getPushedDownFilterInfo();
   if (!filter_push_down_info.empty()) {
     return filter_push_down_info;
@@ -8381,6 +8386,7 @@ void DBHandler::executeDdl(
       _return.timings.kernel_execution_time_ms += rs_ptr->getKernelExecutionTime();
       _return.timings.compilation_time_ms += rs_ptr->getCompilationTime();
       _return.timings.parsing_time_ms += result.getParsingTime();
+      _return.timings.optimizer_time_ms += result.getOptimizationTime();
       convertResultSet(result, *session_ptr, commandStr, _return);
     }
   }

--- a/ThriftHandler/DBHandler.cpp
+++ b/ThriftHandler/DBHandler.cpp
@@ -6463,7 +6463,8 @@ std::vector<PushedDownFilterInfo> DBHandler::execute_rel_alg(
       g_pending_query_interrupt_freq,
       g_optimize_cuda_block_and_grid_sizes};
   const auto parsing_time_ms = _return.getParsingTime();
-  const auto optimizer_time_ms = _return.getOptimizationTime();
+  const auto prev_optimizer_time_ms = _return.getOptimizationTime();
+  const auto optimizer_time_ms = ra_executor.getRelAlgDag()->getOptimizationTime();
   auto execution_time_ms =
       _return.getExecutionTime() + measure<>::execution([&]() {
         _return = ra_executor.executeRelAlgQuery(
@@ -6476,8 +6477,7 @@ std::vector<PushedDownFilterInfo> DBHandler::execute_rel_alg(
   }
   _return.setExecutionTime(execution_time_ms);
   _return.addParsingTime(parsing_time_ms);
-  _return.addOptimizationTime(optimizer_time_ms +
-                              ra_executor.getRelAlgDag()->getOptimizationTime());
+  _return.addOptimizationTime(prev_optimizer_time_ms + optimizer_time_ms);
   const auto& filter_push_down_info = _return.getPushedDownFilterInfo();
   if (!filter_push_down_info.empty()) {
     return filter_push_down_info;

--- a/heavy.thrift
+++ b/heavy.thrift
@@ -189,6 +189,7 @@ struct TTimingInfo {
   6: i64 kernel_execution_time_ms;
   7: i64 compilation_time_ms;
   8: i64 parsing_time_ms;
+  9: i64 optimizer_time_ms;
 }
 
 struct TQueryResult {


### PR DESCRIPTION
## Summary
- record relational optimizer duration in RelAlgDag
- expose optimizer time through ExecutionResult and DBHandler
- print optimizer time in heavysql timing output

## Testing
- `cmake -S . -B build` *(fails: Failed to find nvcc)*

------
https://chatgpt.com/codex/tasks/task_e_68b9011c8324832f99416cf048b91dbb