### PR TITLE
Fix compilation timing aggregation across query steps

### DIFF
--- a/QueryEngine/JoinFilterPushDown.cpp
+++ b/QueryEngine/JoinFilterPushDown.cpp
@@ -243,6 +243,8 @@ ExecutionResult RelAlgExecutor::executeRelAlgQueryWithFilterPushDown(
     eo_modified.just_calcite_explain = false;
 
     // Dispatch the subqueries first
+    int64_t subquery_compilation_time_ms{0};
+    int64_t subquery_compilation_queue_time_ms{0};
     for (auto subquery : subqueries) {
       // Execute the subquery and cache the result.
       RelAlgExecutor ra_executor(executor_, nullptr, gfx_context_);
@@ -251,9 +253,23 @@ ExecutionResult RelAlgExecutor::executeRelAlgQueryWithFilterPushDown(
       RaExecutionSequence subquery_seq(subquery_ra, executor_, eo.just_validate);
       auto result =
           ra_executor.executeRelAlgSeq(subquery_seq, co, eo_modified, nullptr, 0);
+      if (const auto& rows = result.getRows()) {
+        subquery_compilation_time_ms += rows->getCompilationTime();
+        subquery_compilation_queue_time_ms += rows->getCompilationQueueTime();
+      }
       subquery->setExecutionResult(std::make_shared<ExecutionResult>(result));
     }
-    return executeRelAlgSeq(seq, co, eo_modified, render_info, queue_time_ms);
+    auto execution_result =
+        executeRelAlgSeq(seq, co, eo_modified, render_info, queue_time_ms);
+    if (const auto& rows = execution_result.getRows()) {
+      if (subquery_compilation_time_ms) {
+        rows->addCompilationTime(subquery_compilation_time_ms);
+      }
+      if (subquery_compilation_queue_time_ms) {
+        rows->addCompilationQueueTime(subquery_compilation_queue_time_ms);
+      }
+    }
+    return execution_result;
   }
   // else
   return executeRelAlgSeq(seq, co, eo, render_info, queue_time_ms);

--- a/QueryEngine/RelAlgExecutor.cpp
+++ b/QueryEngine/RelAlgExecutor.cpp
@@ -620,6 +620,70 @@ ExecutionResult RelAlgExecutor::executeRelAlgQuery(const CompilationOptions& co,
   return run_query(co_cpu);
 }
 
+namespace {
+
+struct CompilationTimingTotals {
+  int64_t compilation_time{0};
+  int64_t compilation_queue_time{0};
+};
+
+void aggregate_compilation_timings(const RaExecutionSequence& seq,
+                                   const size_t first_step_idx,
+                                   const size_t last_step_idx) {
+  if (last_step_idx < first_step_idx) {
+    return;
+  }
+
+  auto final_desc = seq.getDescriptor(last_step_idx);
+  CHECK(final_desc);
+  const auto final_rows = final_desc->getResult().getRows();
+  if (!final_rows) {
+    return;
+  }
+
+  int64_t total_compilation_time{0};
+  int64_t total_compilation_queue_time{0};
+  for (size_t step_idx = first_step_idx; step_idx <= last_step_idx; ++step_idx) {
+    const auto step_desc = seq.getDescriptor(step_idx);
+    CHECK(step_desc);
+    const auto step_rows = step_desc->getResult().getRows();
+    if (!step_rows) {
+      continue;
+    }
+    total_compilation_time += step_rows->getCompilationTime();
+    total_compilation_queue_time += step_rows->getCompilationQueueTime();
+  }
+
+  final_rows->setCompilationTime(total_compilation_time);
+  final_rows->setCompilationQueueTime(total_compilation_queue_time);
+}
+
+void accumulate_compilation_totals(const ExecutionResult& execution_result,
+                                   CompilationTimingTotals& totals) {
+  const auto& rows = execution_result.getRows();
+  if (!rows) {
+    return;
+  }
+  totals.compilation_time += rows->getCompilationTime();
+  totals.compilation_queue_time += rows->getCompilationQueueTime();
+}
+
+void add_compilation_totals_to_result_set(
+    const std::shared_ptr<ResultSet>& rows,
+    const CompilationTimingTotals& totals) {
+  if (!rows) {
+    return;
+  }
+  if (totals.compilation_time) {
+    rows->addCompilationTime(totals.compilation_time);
+  }
+  if (totals.compilation_queue_time) {
+    rows->addCompilationQueueTime(totals.compilation_queue_time);
+  }
+}
+
+}  // namespace
+
 ExecutionResult RelAlgExecutor::executeRelAlgQueryNoRetry(const CompilationOptions& co,
                                                           const ExecutionOptions& eo,
                                                           const bool just_explain_plan,
@@ -1340,70 +1404,6 @@ void RelAlgExecutor::prepareLeafExecution(
   executor_->table_generations_ = table_generations;
   executor_->agg_col_range_cache_ = agg_col_range;
 }
-
-namespace {
-
-struct CompilationTimingTotals {
-  int64_t compilation_time{0};
-  int64_t compilation_queue_time{0};
-};
-
-void aggregate_compilation_timings(const RaExecutionSequence& seq,
-                                   const size_t first_step_idx,
-                                   const size_t last_step_idx) {
-  if (last_step_idx < first_step_idx) {
-    return;
-  }
-
-  auto final_desc = seq.getDescriptor(last_step_idx);
-  CHECK(final_desc);
-  const auto final_rows = final_desc->getResult().getRows();
-  if (!final_rows) {
-    return;
-  }
-
-  int64_t total_compilation_time{0};
-  int64_t total_compilation_queue_time{0};
-  for (size_t step_idx = first_step_idx; step_idx <= last_step_idx; ++step_idx) {
-    const auto step_desc = seq.getDescriptor(step_idx);
-    CHECK(step_desc);
-    const auto step_rows = step_desc->getResult().getRows();
-    if (!step_rows) {
-      continue;
-    }
-    total_compilation_time += step_rows->getCompilationTime();
-    total_compilation_queue_time += step_rows->getCompilationQueueTime();
-  }
-
-  final_rows->setCompilationTime(total_compilation_time);
-  final_rows->setCompilationQueueTime(total_compilation_queue_time);
-}
-
-void accumulate_compilation_totals(const ExecutionResult& execution_result,
-                                   CompilationTimingTotals& totals) {
-  const auto& rows = execution_result.getRows();
-  if (!rows) {
-    return;
-  }
-  totals.compilation_time += rows->getCompilationTime();
-  totals.compilation_queue_time += rows->getCompilationQueueTime();
-}
-
-void add_compilation_totals_to_result_set(
-    const std::shared_ptr<ResultSet>& rows,
-    const CompilationTimingTotals& totals) {
-  if (!rows) {
-    return;
-  }
-  if (totals.compilation_time) {
-    rows->addCompilationTime(totals.compilation_time);
-  }
-  if (totals.compilation_queue_time) {
-    rows->addCompilationQueueTime(totals.compilation_queue_time);
-  }
-}
-
-}  // namespace
 
 ExecutionResult RelAlgExecutor::executeRelAlgSeq(const RaExecutionSequence& seq,
                                                  const CompilationOptions& co,

--- a/QueryEngine/RelAlgExecutor.cpp
+++ b/QueryEngine/RelAlgExecutor.cpp
@@ -1336,6 +1336,41 @@ void RelAlgExecutor::prepareLeafExecution(
   executor_->agg_col_range_cache_ = agg_col_range;
 }
 
+namespace {
+
+void aggregate_compilation_timings(const RaExecutionSequence& seq,
+                                   const size_t first_step_idx,
+                                   const size_t last_step_idx) {
+  if (last_step_idx < first_step_idx) {
+    return;
+  }
+
+  auto final_desc = seq.getDescriptor(last_step_idx);
+  CHECK(final_desc);
+  const auto final_rows = final_desc->getResult().getRows();
+  if (!final_rows) {
+    return;
+  }
+
+  int64_t total_compilation_time{0};
+  int64_t total_compilation_queue_time{0};
+  for (size_t step_idx = first_step_idx; step_idx <= last_step_idx; ++step_idx) {
+    const auto step_desc = seq.getDescriptor(step_idx);
+    CHECK(step_desc);
+    const auto step_rows = step_desc->getResult().getRows();
+    if (!step_rows) {
+      continue;
+    }
+    total_compilation_time += step_rows->getCompilationTime();
+    total_compilation_queue_time += step_rows->getCompilationQueueTime();
+  }
+
+  final_rows->setCompilationTime(total_compilation_time);
+  final_rows->setCompilationQueueTime(total_compilation_queue_time);
+}
+
+}  // namespace
+
 ExecutionResult RelAlgExecutor::executeRelAlgSeq(const RaExecutionSequence& seq,
                                                  const CompilationOptions& co,
                                                  const ExecutionOptions& eo,
@@ -1450,6 +1485,7 @@ ExecutionResult RelAlgExecutor::executeRelAlgSeq(const RaExecutionSequence& seq,
     }
   }
 
+  aggregate_compilation_timings(seq, 0, num_steps);
   return seq.getDescriptor(num_steps)->getResult();
 }
 
@@ -1499,6 +1535,8 @@ ExecutionResult RelAlgExecutor::executeRelAlgSubSeq(
     }
   }
 
+  CHECK_GT(interval.second, interval.first);
+  aggregate_compilation_timings(seq, interval.first, interval.second - 1);
   return seq.getDescriptor(interval.second - 1)->getResult();
 }
 

--- a/QueryEngine/RelAlgExecutor.cpp
+++ b/QueryEngine/RelAlgExecutor.cpp
@@ -751,6 +751,7 @@ ExecutionResult RelAlgExecutor::executeRelAlgQueryNoRetry(const CompilationOptio
 
   // Dispatch the subqueries first
   const auto global_hints = getGlobalQueryHint();
+  CompilationTimingTotals subquery_compilation_totals;
   for (auto subquery : getSubqueries()) {
     const auto subquery_ra = subquery->getRelAlg();
     CHECK(subquery_ra);
@@ -772,9 +773,13 @@ ExecutionResult RelAlgExecutor::executeRelAlgQueryNoRetry(const CompilationOptio
     }
     RaExecutionSequence subquery_seq(subquery_ra, executor_, eo.just_validate);
     auto result = subquery_executor.executeRelAlgSeq(subquery_seq, co, eo, nullptr, 0);
+    accumulate_compilation_totals(result, subquery_compilation_totals);
     subquery->setExecutionResult(std::make_shared<ExecutionResult>(result));
   }
-  return executeRelAlgSeq(ed_seq, co, eo, render_info, queue_time_ms);
+  auto execution_result = executeRelAlgSeq(ed_seq, co, eo, render_info, queue_time_ms);
+  add_compilation_totals_to_result_set(execution_result.getRows(),
+                                       subquery_compilation_totals);
+  return execution_result;
 }
 
 AggregatedColRange RelAlgExecutor::computeColRangesCache() {
@@ -1338,6 +1343,11 @@ void RelAlgExecutor::prepareLeafExecution(
 
 namespace {
 
+struct CompilationTimingTotals {
+  int64_t compilation_time{0};
+  int64_t compilation_queue_time{0};
+};
+
 void aggregate_compilation_timings(const RaExecutionSequence& seq,
                                    const size_t first_step_idx,
                                    const size_t last_step_idx) {
@@ -1367,6 +1377,30 @@ void aggregate_compilation_timings(const RaExecutionSequence& seq,
 
   final_rows->setCompilationTime(total_compilation_time);
   final_rows->setCompilationQueueTime(total_compilation_queue_time);
+}
+
+void accumulate_compilation_totals(const ExecutionResult& execution_result,
+                                   CompilationTimingTotals& totals) {
+  const auto& rows = execution_result.getRows();
+  if (!rows) {
+    return;
+  }
+  totals.compilation_time += rows->getCompilationTime();
+  totals.compilation_queue_time += rows->getCompilationQueueTime();
+}
+
+void add_compilation_totals_to_result_set(
+    const std::shared_ptr<ResultSet>& rows,
+    const CompilationTimingTotals& totals) {
+  if (!rows) {
+    return;
+  }
+  if (totals.compilation_time) {
+    rows->addCompilationTime(totals.compilation_time);
+  }
+  if (totals.compilation_queue_time) {
+    rows->addCompilationQueueTime(totals.compilation_queue_time);
+  }
 }
 
 }  // namespace

--- a/QueryEngine/ResultSet.cpp
+++ b/QueryEngine/ResultSet.cpp
@@ -724,12 +724,20 @@ void ResultSet::setKernelQueueTime(const int64_t kernel_queue_time) {
   timings_.kernel_queue_time = kernel_queue_time;
 }
 
+void ResultSet::setCompilationQueueTime(const int64_t compilation_queue_time) {
+  timings_.compilation_queue_time = compilation_queue_time;
+}
+
 void ResultSet::addCompilationQueueTime(const int64_t compilation_queue_time) {
   timings_.compilation_queue_time += compilation_queue_time;
 }
 
 void ResultSet::setKernelExecutionTime(const int64_t kernel_execution_time) {
   timings_.kernel_execution_time = kernel_execution_time;
+}
+
+void ResultSet::setCompilationTime(const int64_t compilation_time) {
+  timings_.compilation_time = compilation_time;
 }
 
 void ResultSet::addCompilationTime(const int64_t compilation_time) {

--- a/QueryEngine/ResultSet.h
+++ b/QueryEngine/ResultSet.h
@@ -392,8 +392,10 @@ class ResultSet {
 
   void setQueueTime(const int64_t queue_time);
   void setKernelQueueTime(const int64_t kernel_queue_time);
+  void setCompilationQueueTime(const int64_t compilation_queue_time);
   void addCompilationQueueTime(const int64_t compilation_queue_time);
   void setKernelExecutionTime(const int64_t kernel_execution_time);
+  void setCompilationTime(const int64_t compilation_time);
   void addCompilationTime(const int64_t compilation_time);
 
   int64_t getQueueTime() const;


### PR DESCRIPTION
## Summary
- add aggregation of compilation and queue timings across multi-step query execution sequences before returning the final result
- add setters on ResultSet for compilation timing fields used by the new aggregation logic

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c45671a9ec832fb295ac0c0ab1d9c1