### PR TITLE
Fix compilation time aggregation across work units

### DIFF
--- a/QueryEngine/Execute.cpp
+++ b/QueryEngine/Execute.cpp
@@ -2155,6 +2155,7 @@ ResultSetPtr Executor::executeWorkUnit(size_t& max_groups_buffer_entry_guess,
   VLOG(1) << "Executor " << executor_id_ << " is executing work unit:" << ra_exe_unit_in;
   auto copied_co = co;
   copied_co.device_type = getDeviceTypeForTargets(ra_exe_unit_in, co.device_type);
+  compilation_time_ms_ = 0;
   ScopeGuard cleanup_post_execution = [this] {
     // cleanup/unpin GPU buffer allocations
     // TODO: separate out this state into a single object
@@ -2412,6 +2413,7 @@ void Executor::executeWorkUnitPerFragment(
     const Catalog_Namespace::Catalog& cat,
     PerFragmentCallBack& cb,
     const std::set<size_t>& fragment_indexes_param) {
+  compilation_time_ms_ = 0;
   const auto [ra_exe_unit, deleted_cols_map] = addDeletedColumn(ra_exe_unit_in, co);
   ColumnCacheMap column_cache;
 
@@ -2491,6 +2493,7 @@ ResultSetPtr Executor::executeTableFunction(
     const ExecutionOptions& eo,
     gfx::GfxContext* gfx_context) {
   INJECT_TIMER(Exec_executeTableFunction);
+  compilation_time_ms_ = 0;
   if (eo.just_validate) {
     QueryMemoryDescriptor query_mem_desc(this,
                                          /*entry_count=*/0,

--- a/QueryEngine/NativeCodegen.cpp
+++ b/QueryEngine/NativeCodegen.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "QueryEngine/Execute.h"
+#include "Shared/scope.h"
 
 #if LLVM_VERSION_MAJOR < 14
 static_assert(false, "LLVM Version >= 14 is required.");
@@ -2930,6 +2931,10 @@ Executor::compileWorkUnit(const std::vector<InputTableInfo>& query_infos,
                           ColumnCacheMap& column_cache,
                           RenderInfo* render_info) {
   auto timer = DEBUG_TIMER(__func__);
+  const auto previous_compilation_time_ms = compilation_time_ms_;
+  ScopeGuard restore_compilation_time = [this, previous_compilation_time_ms]() {
+    compilation_time_ms_ += previous_compilation_time_ms;
+  };
 
   auto compile_begin = timer_start();
   if (co.device_type == ExecutorDeviceType::GPU) {


### PR DESCRIPTION
## Summary
- reset executor compilation timing before running work units, per-fragment kernels, and table functions so totals start from a clean slate
- preserve accumulated compilation time across compileWorkUnit invocations via a scope guard that restores the previous total

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9bc68cf98832fbb27485aa01c47de